### PR TITLE
Avoid fatal errors if GD isn't installed

### DIFF
--- a/class-debug-bar-media.php
+++ b/class-debug-bar-media.php
@@ -197,7 +197,7 @@ class Debug_Bar_Media extends Debug_Bar_Panel {
 
 		// Return early if we already know the GD version.
 		if ( ! $this->gd_version ) {
-			$gd = gd_info();
+			$gd = ( is_callable( 'gd_info' ) ) ? gd_info() : false;
 			$this->gd_version = is_array( $gd ) ? $gd['GD Version'] : 'GD not available';
 		}
 


### PR DESCRIPTION
This adds an `is_callable()` check before calling `gd_info()` to avoid fatal errors that can occur if the plugin is active on a site without GD support.